### PR TITLE
adjust mix_dia_compiler to Elixir 1.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: elixir
 elixir:
-    - 1.2.0
-    - 1.3.0
+    - 1.7.0
+    - 1.8.0
+    - 1.9.0
 otp_release:
-    - 18.0
-    - 19.0
+    - 20.0
+    - 21.0
 script: "mix test"

--- a/lib/mix/tasks/compile.dia.ex
+++ b/lib/mix/tasks/compile.dia.ex
@@ -41,18 +41,29 @@ defmodule Mix.Tasks.Compile.Dia do
       input, output ->
         :ok = Filelib.ensure_dir(output)
         app_path = Mix.Project.app_path(project)
-        include_path = to_char_list Path.join(app_path, project[:erlc_include_path])
+        include_path = to_charlist Path.join(app_path, project[:erlc_include_path])
         :ok = Path.join(include_path, "dummy.hrl") |> Filelib.ensure_dir
         case DiaDictUtil.parse({:path, input}, []) do
           {:ok, spec} ->
             filename = dia_filename(input, spec)
             _ = DiaCodegen.from_dict(filename, spec, [{:outdir, 'src'} | options], :erl)
             _ = DiaCodegen.from_dict(filename, spec, [{:outdir, include_path} | options], :hrl)
-            file = to_char_list Path.join("src", filename)
-            compile_path = to_char_list Mix.Project.compile_path(project)
+            file = to_charlist(Path.join("src", filename))
+            compile_path = to_charlist Mix.Project.compile_path(project)
             erlc_options = project[:erlc_options] || []
             erlc_options = erlc_options ++ [{:outdir, compile_path}, {:i, include_path}, :report]
-            :compile.file(file, erlc_options)
+            case :compile.file(file, erlc_options) do
+              {:ok, module} ->
+                {:ok, module, []}
+              {:ok, module, warnings} ->
+                {:ok, module, warnings}
+              {:ok, module, _binary, warnings} ->
+                {:ok, module, warnings}
+              {:error, errors, warnings} ->
+                {:error, errors, warnings}
+              :error ->
+                {:error, [], []}
+            end
           error -> Mix.raise "Diameter compiler error: #{inspect error}"
         end
     end)
@@ -73,7 +84,8 @@ defmodule Mix.Tasks.Compile.Dia do
 
   defp dia_filename(file, spec) do
     case spec[:name] do
-      :undefined -> Path.basename(file) |> Path.rootname
+      nil -> Path.basename(file) |> Path.rootname |> to_charlist
+      :undefined -> Path.basename(file) |> Path.rootname |> to_charlist
       name -> name
     end
   end

--- a/lib/mix/tasks/compile.dia.ex
+++ b/lib/mix/tasks/compile.dia.ex
@@ -25,6 +25,15 @@ defmodule Mix.Tasks.Compile.Dia do
       For a list of the many more available options,
       see [`:diameter_make`](http://erlang.org/doc/man/diameter_make.html).
       Note that the `:outdir` option is overridden by this compiler.
+
+    * `:dia_erl_compile_opts` list of options that will be passed to
+      Mix.Compilers.Erlang.compile/6
+
+      Following options are supported:
+
+        * :force        - boolean
+        * :verbose      - boolean
+        * :all_warnings - boolean
   """
 
   @doc """
@@ -33,11 +42,12 @@ defmodule Mix.Tasks.Compile.Dia do
   @spec run(OptionParser.argv) :: :ok | :noop
   def run(_args) do
     project      = Mix.Project.config
+    erlang_compile_opts = project[:dia_erl_compile_opts] || []
     source_paths = project[:erlc_paths]
     mappings     = Enum.zip(["dia"], source_paths)
     options      = project[:dia_options] || []
 
-    Erlang.compile(manifest(), mappings, :dia, :erl, [], fn
+    Erlang.compile(manifest(), mappings, :dia, :erl, erlang_compile_opts, fn
       input, output ->
         :ok = Filelib.ensure_dir(output)
         app_path = Mix.Project.app_path(project)

--- a/mix.exs
+++ b/mix.exs
@@ -7,9 +7,9 @@ defmodule MixDiaCompiler.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
-     description: description,
-     package: package]
+     deps: deps(),
+     description: description(),
+     package: package()]
   end
 
   def application do

--- a/test/compile.dia_test.exs
+++ b/test/compile.dia_test.exs
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Compile.DiaTest do
       -module(zzz).
       """
 
-      assert Mix.Tasks.Compile.Dia.run([]) == :ok
+      assert Mix.Tasks.Compile.Dia.run([]) == {:ok, []}
 
       assert File.regular?("src/a.erl")
       assert File.regular?("_build/test/lib/sample/include/a.hrl")
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Compile.DiaTest do
       # just dia files should be compiled
       assert not File.regular?("_build/test/lib/sample/ebin/zzz.beam")
 
-      assert Mix.Tasks.Compile.Erlang.run([]) == :ok
+      assert Mix.Tasks.Compile.Erlang.run([]) == {:ok, []}
       assert File.regular?("_build/test/lib/sample/ebin/zzz.beam")
       assert File.regular?("_build/test/lib/sample/ebin/a.beam")
       assert stat0 == File.stat! "_build/test/lib/sample/ebin/a.beam"
@@ -66,7 +66,7 @@ defmodule Mix.Tasks.Compile.DiaTest do
          IMSI 1 UTF8String V
       """
 
-      assert Mix.Tasks.Compile.Dia.run([]) == :ok
+      assert Mix.Tasks.Compile.Dia.run([]) == {:ok, []}
 
       assert File.regular?("src/a.erl")
       assert File.regular?("_build/test/lib/sample/include/a.hrl")
@@ -93,7 +93,7 @@ defmodule Mix.Tasks.Compile.DiaTest do
          IMEIV 900 OctetString MV
       """
 
-      assert Mix.Tasks.Compile.Dia.run([]) == :ok
+      assert Mix.Tasks.Compile.Dia.run([]) == {:ok, []}
 
       assert File.regular?("src/a.erl")
       assert File.regular?("_build/test/lib/sample/include/a.hrl")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -90,7 +90,7 @@ defmodule MixTest.Case do
   def in_fixture(which, tmp, function) do
     src  = fixture_path(which)
     dest = tmp_path(tmp)
-    flag = String.to_char_list(tmp_path())
+    flag = String.to_charlist(tmp_path())
 
     File.rm_rf!(dest)
     File.mkdir_p!(dest)
@@ -124,7 +124,7 @@ defmodule MixTest.Case do
   end
 
   defp delete_tmp_paths do
-    tmp = tmp_path() |> String.to_char_list
+    tmp = tmp_path() |> String.to_charlist
     for path <- :code.get_path,
         :string.str(path, tmp) != 0,
         do: :code.del_path(path)


### PR DESCRIPTION
This commit fixes deprecations like

Erlang.compile callback should return {:ok, contents, warnings}
or {:error, errors, warnings}

For more info see https://hexdocs.pm/elixir/compatibility-and-deprecations.html.

In addition this PR provides ability to pass options for Erlang.compile/6, it can be useful during forcing compilation of diameter dictionaries for different MIX_ENV(s)