### PR TITLE
Fix warnings related to Elixir 1.11

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule MixDiaCompiler.Mixfile do
      start_permanent: Mix.env == :prod,
      deps: deps(),
      description: description(),
+     xref: [exclude: [:diameter_codegen, :diameter_dict_util]],
      package: package()]
   end
 


### PR DESCRIPTION
mix_dia_compiler uses API of diameter application, but the application
itself is not started (as not used). Elixir 1.11 throws warning
messages in this case.

This commit fixes it.